### PR TITLE
Added PoolHex param to identify pool server

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -8,7 +8,10 @@ var util = require('./util.js');
  * The BlockTemplate class holds a single job.
  * and provides several methods to validate and submit it to the daemon coin
 **/
-var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, extraNoncePlaceholder, reward, recipients, poolAddress, coin, pubkey){
+
+// added poolHex to template
+
+var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, extraNoncePlaceholder, reward, recipients, poolAddress, poolHex, coin, pubkey){
 
     //private members
     var submits = [];
@@ -50,7 +53,7 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, extr
      else
      {
        if (typeof this.genTx === 'undefined') {
-  	      this.genTx = transactions.createGeneration(rpcData.height, blockReward, this.rewardFees, recipients, poolAddress, coin).toString('hex');
+  	      this.genTx = transactions.createGeneration(rpcData.height, blockReward, this.rewardFees, recipients, poolAddress, poolHex, coin).toString('hex');
 	        this.genTxHash = transactions.txHash();
        }
        this.txCount = this.rpcData.transactions.length + 1; // add total txs and new coinbase

--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -112,6 +112,7 @@ var JobManager = module.exports = function JobManager(options) {
             options.coin.reward,
             options.recipients,
             options.address,
+            options.poolHex,
             options.coin,
             options.pubkey
         );
@@ -148,6 +149,7 @@ var JobManager = module.exports = function JobManager(options) {
             options.coin.reward,
             options.recipients,
             options.address,
+            options.poolHex,
             options.coin,
             options.pubkey
         );

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,0 +1,44 @@
+{
+    "name": "stratum-pool",
+    "version": "0.2.0",
+    "description": "High performance Komodo stratum poolserver in Node.js",
+    "keywords": [
+        "stratum",
+        "mining",
+        "pool",
+        "server",
+        "poolserver",
+        "komodo"
+    ],
+    "homepage": "https://github.com/webworker01/node-stratum-pool",
+    "bugs": {
+        "url": "https://github.com/webworker01/node-stratum-pool/issues"
+    },
+    "license": "GPL-2.0",
+    "author": "webworker01",
+    "contributors": [
+        "ComputerGenie",
+        "Matthew Little",
+        "vekexasia",
+        "TheSeven",
+        "joshuayabut"
+    ],
+    "main": "lib/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/webworker01/node-stratum-pool.git"
+    },
+    "dependencies": {
+        "async": "^2.6.1",
+        "base58-native": "^0.1.4",
+        "bignum": "^0.13.0",
+        "bitgo-utxo-lib": "git+https://github.com/miketout/bitgo-utxo-lib.git",
+        "equihashverify": "git+https://github.com/webworker01/equihashverify.git",
+        "merkle-bitcoin": "git+https://github.com/joshuayabut/merkle-bitcoin.git#3606036e3a44aa46e5a16cc6d7beea8e49dec8ef",
+        "promise": "^8.0.2",
+        "verushash": "git+https://github.com/VerusCoin/verushash-node.git"
+    },
+    "engines": {
+        "node": ">=8"
+    }
+}

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -39,7 +39,7 @@ function scriptCompileP2PK(pubkey) {
 	return script;
 }
 
-exports.createGeneration = function (blockHeight, blockReward, feeReward, recipients, poolAddress, coin, pubkey) {
+exports.createGeneration = function (blockHeight, blockReward, feeReward, recipients, poolAddress, poolHex, coin, pubkey) {
 	let usep2pk = typeof coin.p2pk == 'undefined' || !coin.p2pk ? false : true;
 
 	if (!usep2pk) {
@@ -75,11 +75,21 @@ exports.createGeneration = function (blockHeight, blockReward, feeReward, recipi
 				new Buffer('00', 'hex') // OP_0
 			]);
 
+txb.addInput(new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex'),
+        4294967295,
+        4294967295,
+        new Buffer.concat([
+            serializedBlockHeight,
+            // http://pool.entrustus.org:8083/
+            Buffer(poolHex ? poolHex : '687474703a2f2f706f6f6c2e656e747275737475732e6f72673a383038332f', 'hex')
+        ])
+    )
+/*
 	txb.addInput(new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex'),
 		4294967295,
 		4294967295,
 		new Buffer.concat([serializedBlockHeight]));
-
+*/
 	// calculate total fees
 	var feePercent = 0;
 	for (var i = 0; i < recipients.length; i++) {
@@ -135,8 +145,8 @@ exports.createGeneration = function (blockHeight, blockReward, feeReward, recipi
 	// assign
 	txHash = tx.getHash().toString('hex');
 
-	// console.log('txHex: ' + txHex);
-	// console.log('txHash: ' + txHash);
+//	console.log('txHex: ' + txHex);
+//	console.log('txHash: ' + txHash);
 
 	return txHex;
 };


### PR DESCRIPTION
added s-nomp and z-nomp's poolHex (pool identification) configuration variable to config.json & your stratum-pool. if you would like to test. I've tested for a few days and working fine. i just needed to add my own signature to my explorer's pool.json config file.

```   "redis": {
            "host": "127.0.0.1",
            "port": 6379
        },
	 "poolHex": "687474703a2f2f706f6f6c2e656e747275737475732e6f72673a383038332f",
	"_comment_poolHex": "hex = http://pool.entrustus.org:8083/"
    },```

